### PR TITLE
allow spaces in command line arguments

### DIFF
--- a/application/src/main/bin/jqassistant.sh
+++ b/application/src/main/bin/jqassistant.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 BIN_DIR=`dirname "$0"`
 export JQASSISTANT_HOME=`cd "$BIN_DIR/.." && pwd -P`
-java $JQASSISTANT_OPTS -jar "$JQASSISTANT_HOME/lib/${project.groupId}-${project.artifactId}-${project.version}.${project.packaging}" $*
-
+java $JQASSISTANT_OPTS -jar "$JQASSISTANT_HOME/lib/${project.groupId}-${project.artifactId}-${project.version}.${project.packaging}" "$@"


### PR DESCRIPTION
Had some trouble using the command line tool if paths (e.g., for -f parameter) contains spaces, so I adopted the shell script.